### PR TITLE
Раскомментировал строки из предыдущего фикса. Добавил новый фикс

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -279,7 +279,14 @@ public class AudioService extends MediaBrowserServiceCompat {
             }
         };
 
-        flutterEngine = AudioServicePlugin.getFlutterEngine(this);
+        // TODO(tharkahov): Комментирование этой строки чинит чёрный экран
+        //  на андроиде в приложении The Hole.
+        //  По сути прила застревает на SplashScreen.
+        //  Видимо потому, что если ранее был вызван этот метод из сервиса,
+        //  то при старте активити не вызывается onAttachedToEngine.
+        //  Воспроизводится не на все девайсах
+        //  Самые проблемные Samsung и OnePlus, а также LineageOs 17
+//        flutterEngine = AudioServicePlugin.getFlutterEngine(this);
         System.out.println("flutterEngine warmed up");
     }
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -248,10 +248,9 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
             audioHandlerInterface = new AudioHandlerInterface(flutterPluginBinding.getBinaryMessenger());
             AudioService.init(audioHandlerInterface);
         }
-        // TODO fixing black screen
-//        if (mediaBrowser == null) {
-//            connect();
-//        }
+        if (mediaBrowser == null) {
+            connect();
+        }
     }
 
     @Override
@@ -284,10 +283,9 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         clientInterface.setWrongEngineDetected(flutterPluginBinding.getBinaryMessenger() != sharedEngine.getDartExecutor());
         mainClientInterface = clientInterface;
         registerOnNewIntentListener();
-        // TODO fixing black screen
-//        if (mediaController != null) {
-//            MediaControllerCompat.setMediaController(mainClientInterface.activity, mediaController);
-//        }
+        if (mediaController != null) {
+            MediaControllerCompat.setMediaController(mainClientInterface.activity, mediaController);
+        }
         if (mediaBrowser == null) {
             connect();
         }


### PR DESCRIPTION
Комментирование строки в `AudioService.onCreate` чинит чёрный экран на андроиде в приложении The Hole.

По сути прила застревает на SplashScreen. Видимо потому, что если ранее был вызван этот метод из сервиса, то при старте активити не вызывается onAttachedToEngine.

Воспроизводится не на все девайсах. Самые проблемные Samsung и OnePlus, а также LineageOs 17.

Возможные проблемы:
 - мы никогда не сможем получить flutterEngine при старте сервиса из бэкграунда
 - возможны проблемы при перезапуске приложения или сервиса системой (если мало памяти??)

Кажется, что это не должно затрагивать наши типичные сценарии.