### PR TITLE
fix: play-pause controls update properly

### DIFF
--- a/audio_service/darwin/Classes/AudioServicePlugin.m
+++ b/audio_service/darwin/Classes/AudioServicePlugin.m
@@ -329,7 +329,7 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     // Shift the actionBits right until the least significant bit is the tested action bit, and AND that with a 1 at the same position.
     // All bytes become 0, other than the tested action bit, which will be 0 or 1 according to its status in the actionBits long.
     BOOL enable = ((actionBits >> action) & 1);
-    if (_controlsUpdated && enable == command.enabled) return;
+    if (_controlsUpdated && !command.enabled && !enable) return;
     //NSLog(@"## updateControl %@ enable=%@", @(action), @(enable));
     [command setEnabled:enable];
     switch (action) {


### PR DESCRIPTION
Fix for this: controls did not update state when the session got paused upon removing headphone jack